### PR TITLE
Add test-specific OpenTelemetry settings to application.properties:

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,10 @@
+%test.quarkus.otel.metrics.enabled=false
+%test.quarkus.otel.logs.enabled=false
+
 quarkus.otel.metrics.enabled=true
 quarkus.otel.logs.enabled=true
 quarkus.application.name=quarkus-pg
 quarkus.otel.exporter.otlp.endpoint=http://lgtm:4317
-
-
 
 quarkus.datasource.db-kind=postgresql
 


### PR DESCRIPTION
- Disable OpenTelemetry metrics and logs for the `test` profile.