### PR TITLE
Introduce Pokemon entity, database schema, and integrations:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,21 @@
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-logging</artifactId>
         </dependency>
+        <!-- Flyway specific dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway</artifactId>
+        </dependency>
+        <!-- JDBC driver dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-postgresql</artifactId>
+        </dependency>
+        <!-- Flyway PostgreSQL specific dependencies -->
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>

--- a/src/main/java/mx/tiempor3al/models/Pokemon.java
+++ b/src/main/java/mx/tiempor3al/models/Pokemon.java
@@ -1,0 +1,39 @@
+package mx.tiempor3al.models;
+
+import io.vertx.mutiny.sqlclient.Row;
+
+import java.math.BigDecimal;
+
+public record Pokemon(
+    Long id,
+    String name,
+    Long typeId,
+    String typeName,
+    BigDecimal height,
+    BigDecimal weight,
+    Integer hp,
+    Integer attack,
+    Integer defense,
+    Integer specialAttack,
+    Integer specialDefense,
+    Integer speed,
+    String description
+) {
+    public static Pokemon fromRecord(Row row) {
+        return new Pokemon(
+            row.getLong("id"),
+            row.getString("name"),
+            row.getLong("type_id"),
+            row.getString("type_name"),
+            row.getBigDecimal("height"),
+            row.getBigDecimal("weight"),
+            row.getInteger("hp"),
+            row.getInteger("attack"),
+            row.getInteger("defense"),
+            row.getInteger("special_attack"),
+            row.getInteger("special_defense"),
+            row.getInteger("speed"),
+            row.getString("description")
+        );
+    }
+}

--- a/src/main/java/mx/tiempor3al/resources/RootResource.java
+++ b/src/main/java/mx/tiempor3al/resources/RootResource.java
@@ -1,17 +1,18 @@
 package mx.tiempor3al.resources;
 
 import io.quarkus.logging.Log;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import mx.tiempor3al.models.Pokemon;
 import mx.tiempor3al.services.DBService;
 
 @Path("/")
 public class RootResource {
-
 
     @Inject
     DBService dbService;
@@ -22,5 +23,13 @@ public class RootResource {
     public Uni<String> version() {
         Log.info("GET version");
         return dbService.version();
+    }
+
+    @GET
+    @Path("/pokemons")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Multi<Pokemon> getAllPokemons() {
+        Log.info("GET all pokemons");
+        return dbService.getAllPokemons();
     }
 }

--- a/src/main/java/mx/tiempor3al/services/DBService.java
+++ b/src/main/java/mx/tiempor3al/services/DBService.java
@@ -1,9 +1,11 @@
 package mx.tiempor3al.services;
 
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.sqlclient.Pool;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import mx.tiempor3al.models.Pokemon;
 
 @ApplicationScoped
 public class DBService {
@@ -16,4 +18,15 @@ public class DBService {
                 .onItem().transform(set -> set.iterator().next().getString(0));
     }
 
+    public Multi<Pokemon> getAllPokemons() {
+        String query = "SELECT p.id, p.name, p.type_id, pt.name as type_name, p.height, p.weight, " +
+                "p.hp, p.attack, p.defense, p.special_attack, p.special_defense, p.speed, p.description " +
+                "FROM pokemon p " +
+                "JOIN pokemon_types pt ON p.type_id = pt.id " +
+                "ORDER BY p.id";
+
+        return client.query(query).execute()
+                .onItem().transformToMulti(rows -> Multi.createFrom().iterable(rows))
+                .onItem().transform(Pokemon::fromRecord);
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,3 +15,9 @@ quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=${POSTGRES_USER}
 quarkus.datasource.password=${POSTGRES_PASSWORD}
 quarkus.datasource.reactive.url=postgresql://postgres-service:5432/${POSTGRES_DB}
+
+quarkus.datasource.jdbc.url=jdbc:postgresql://postgres-service:5432/${POSTGRES_DB}
+
+%test.quarkus.flyway.migrate-at-start=false
+# Run Flyway migrations automatically
+quarkus.flyway.migrate-at-start=true

--- a/src/main/resources/db/migration/V1__create_pokemon_tables.sql
+++ b/src/main/resources/db/migration/V1__create_pokemon_tables.sql
@@ -1,0 +1,53 @@
+-- Create Pokemon-related tables
+
+-- Pokemon types table
+CREATE TABLE IF NOT EXISTS pokemon_types (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(50) NOT NULL UNIQUE,
+    description TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Pokemon table
+CREATE TABLE IF NOT EXISTS pokemon (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    type_id INTEGER NOT NULL REFERENCES pokemon_types(id),
+    height DECIMAL(5, 2), -- in meters
+    weight DECIMAL(6, 2), -- in kg
+    hp INTEGER NOT NULL,
+    attack INTEGER NOT NULL,
+    defense INTEGER NOT NULL,
+    special_attack INTEGER NOT NULL,
+    special_defense INTEGER NOT NULL,
+    speed INTEGER NOT NULL,
+    description TEXT,
+    evolution_level INTEGER,
+    evolution_to_id INTEGER REFERENCES pokemon(id),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Trainers table
+CREATE TABLE IF NOT EXISTS trainers (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    hometown VARCHAR(100),
+    region VARCHAR(100),
+    badges INTEGER DEFAULT 0,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Pokemon ownership table (relationship between trainers and pokemon)
+CREATE TABLE IF NOT EXISTS trainer_pokemon (
+    id SERIAL PRIMARY KEY,
+    trainer_id INTEGER NOT NULL REFERENCES trainers(id),
+    pokemon_id INTEGER NOT NULL REFERENCES pokemon(id),
+    nickname VARCHAR(100),
+    level INTEGER NOT NULL DEFAULT 1,
+    caught_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);

--- a/src/main/resources/db/migration/V2__insert_pokemon_data.sql
+++ b/src/main/resources/db/migration/V2__insert_pokemon_data.sql
@@ -1,0 +1,56 @@
+-- Insert sample Pokemon data
+
+-- Insert Pokemon types
+INSERT INTO pokemon_types (name, description) VALUES
+    ('Normal', 'Normal-type Pokemon with standard attacks'),
+    ('Fire', 'Fire-type Pokemon with heat-based attacks'),
+    ('Water', 'Water-type Pokemon with aquatic abilities'),
+    ('Electric', 'Electric-type Pokemon with lightning powers'),
+    ('Grass', 'Grass-type Pokemon with plant-based abilities'),
+    ('Ice', 'Ice-type Pokemon with freezing abilities'),
+    ('Fighting', 'Fighting-type Pokemon with martial arts skills'),
+    ('Poison', 'Poison-type Pokemon with toxic abilities'),
+    ('Ground', 'Ground-type Pokemon with earth-based powers'),
+    ('Flying', 'Flying-type Pokemon that can soar through the air'),
+    ('Psychic', 'Psychic-type Pokemon with mental powers'),
+    ('Bug', 'Bug-type Pokemon resembling insects'),
+    ('Rock', 'Rock-type Pokemon with stone-based defenses'),
+    ('Ghost', 'Ghost-type Pokemon with supernatural abilities'),
+    ('Dragon', 'Dragon-type Pokemon with mythical powers'),
+    ('Dark', 'Dark-type Pokemon with shadow-based abilities'),
+    ('Steel', 'Steel-type Pokemon with metallic defenses'),
+    ('Fairy', 'Fairy-type Pokemon with magical abilities');
+
+-- Insert Pokemon
+INSERT INTO pokemon (name, type_id, height, weight, hp, attack, defense, special_attack, special_defense, speed, description) VALUES
+    ('Pikachu', 4, 0.4, 6.0, 35, 55, 40, 50, 50, 90, 'An Electric-type Pokemon that stores electricity in its cheeks'),
+    ('Charizard', 2, 1.7, 90.5, 78, 84, 78, 109, 85, 100, 'A Fire/Flying-type Pokemon that breathes fire'),
+    ('Bulbasaur', 5, 0.7, 6.9, 45, 49, 49, 65, 65, 45, 'A Grass/Poison-type Pokemon with a plant bulb on its back'),
+    ('Squirtle', 3, 0.5, 9.0, 44, 48, 65, 50, 64, 43, 'A Water-type Pokemon with a shell'),
+    ('Jigglypuff', 1, 0.5, 5.5, 115, 45, 20, 45, 25, 20, 'A Normal/Fairy-type Pokemon known for its singing'),
+    ('Mewtwo', 11, 2.0, 122.0, 106, 110, 90, 154, 90, 130, 'A Psychic-type legendary Pokemon created by genetic manipulation'),
+    ('Gyarados', 3, 6.5, 235.0, 95, 125, 79, 60, 100, 81, 'A Water/Flying-type Pokemon known for its fierce temperament'),
+    ('Snorlax', 1, 2.1, 460.0, 160, 110, 65, 65, 110, 30, 'A Normal-type Pokemon that loves to eat and sleep'),
+    ('Eevee', 1, 0.3, 6.5, 55, 55, 50, 45, 65, 55, 'A Normal-type Pokemon with unstable genetic makeup'),
+    ('Dragonite', 15, 2.2, 210.0, 91, 134, 95, 100, 100, 80, 'A Dragon/Flying-type Pokemon that can fly around the world');
+
+-- Insert Trainers
+INSERT INTO trainers (name, hometown, region, badges) VALUES
+    ('Ash Ketchum', 'Pallet Town', 'Kanto', 8),
+    ('Misty', 'Cerulean City', 'Kanto', 8),
+    ('Brock', 'Pewter City', 'Kanto', 8),
+    ('Gary Oak', 'Pallet Town', 'Kanto', 10),
+    ('Lance', 'Blackthorn City', 'Johto', 16);
+
+-- Insert Trainer-Pokemon relationships
+INSERT INTO trainer_pokemon (trainer_id, pokemon_id, nickname, level) VALUES
+    (1, 1, 'Pika', 50),  -- Ash's Pikachu
+    (1, 2, 'Char', 36),  -- Ash's Charizard
+    (1, 3, 'Bulby', 32), -- Ash's Bulbasaur
+    (1, 4, 'Squirt', 31), -- Ash's Squirtle
+    (2, 7, 'Gyara', 52),  -- Misty's Gyarados
+    (3, 8, 'Snor', 46),   -- Brock's Snorlax
+    (4, 2, 'Blaze', 55),  -- Gary's Charizard
+    (4, 9, 'Eve', 48),    -- Gary's Eevee
+    (5, 10, 'Drake', 75), -- Lance's Dragonite
+    (5, 6, 'Psy', 80);    -- Lance's Mewtwo

--- a/src/test/java/mx/tiempor3al/RootResourceTest.java
+++ b/src/test/java/mx/tiempor3al/RootResourceTest.java
@@ -2,9 +2,13 @@ package mx.tiempor3al;
 
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import mx.tiempor3al.models.Pokemon;
 import mx.tiempor3al.services.DBService;
 import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
@@ -27,4 +31,45 @@ class RootResourceTest {
             .body(is("1.0.0"));
     }
 
+    @Test
+    void testPokemonsEndpoint() {
+        // Create a sample Pokemon record
+        Pokemon pokemon = new Pokemon(
+            1L,
+            "Pikachu",
+            4L,
+            "Electric",
+            new BigDecimal("0.4"),
+            new BigDecimal("6.0"),
+            35,
+            55,
+            40,
+            50,
+            50,
+            90,
+            "An Electric-type Pokemon that stores electricity in its cheeks"
+        );
+
+        // Mock the DBService to return a stream with our sample Pokemon
+        when(dbService.getAllPokemons()).thenReturn(Multi.createFrom().item(pokemon));
+
+        // Test the endpoint
+        given()
+            .when().get("/pokemons")
+            .then()
+                .statusCode(200)
+                .body("[0].id", is(1))
+                .body("[0].name", is("Pikachu"))
+                .body("[0].typeId", is(4))
+                .body("[0].typeName", is("Electric"))
+                .body("[0].height", is(0.4f))
+                .body("[0].weight", is(6.0f))
+                .body("[0].hp", is(35))
+                .body("[0].attack", is(55))
+                .body("[0].defense", is(40))
+                .body("[0].specialAttack", is(50))
+                .body("[0].specialDefense", is(50))
+                .body("[0].speed", is(90))
+                .body("[0].description", is("An Electric-type Pokemon that stores electricity in its cheeks"));
+    }
 }


### PR DESCRIPTION
- Add `Pokemon` record model with data mapping methods.
- Create database schema migration scripts for `pokemon`, `pokemon_types`, `trainers`, and `trainer_pokemon` tables.
- Seed database with sample data for Pokemon, types, trainers, and relationships.
- Implement `/pokemons` endpoint in `RootResource` to fetch all Pokemon with associated type information.
- Enhance `DBService` with `getAllPokemons` method for database access.
- Update tests to validate `/pokemons` endpoint functionality.
- Add Flyway dependencies for database migrations and integrate Flyway with application startup.