### PR TITLE
Add `/trainers/{trainerId}/pokemons` endpoint to fetch trainer-specif…

### DIFF
--- a/src/main/java/mx/tiempor3al/resources/RootResource.java
+++ b/src/main/java/mx/tiempor3al/resources/RootResource.java
@@ -6,6 +6,7 @@ import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import mx.tiempor3al.models.Pokemon;
@@ -31,5 +32,13 @@ public class RootResource {
     public Multi<Pokemon> getAllPokemons() {
         Log.info("GET all pokemons");
         return dbService.getAllPokemons();
+    }
+
+    @GET
+    @Path("/trainers/{trainerId}/pokemons")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Multi<Pokemon> getPokemonsByTrainer(@PathParam("trainerId") Long trainerId) {
+        Log.info("GET pokemons for trainer: " + trainerId);
+        return dbService.getPokemonsByTrainer(trainerId);
     }
 }

--- a/src/main/java/mx/tiempor3al/services/DBService.java
+++ b/src/main/java/mx/tiempor3al/services/DBService.java
@@ -3,6 +3,7 @@ package mx.tiempor3al.services;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.sqlclient.Pool;
+import io.vertx.mutiny.sqlclient.Tuple;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import mx.tiempor3al.models.Pokemon;
@@ -26,6 +27,20 @@ public class DBService {
                 "ORDER BY p.id";
 
         return client.query(query).execute()
+                .onItem().transformToMulti(rows -> Multi.createFrom().iterable(rows))
+                .onItem().transform(Pokemon::fromRecord);
+    }
+
+    public Multi<Pokemon> getPokemonsByTrainer(Long trainerId) {
+        String query = "SELECT p.id, p.name, p.type_id, pt.name as type_name, p.height, p.weight, " +
+                "p.hp, p.attack, p.defense, p.special_attack, p.special_defense, p.speed, p.description " +
+                "FROM pokemon p " +
+                "JOIN pokemon_types pt ON p.type_id = pt.id " +
+                "JOIN trainer_pokemon tp ON p.id = tp.pokemon_id " +
+                "WHERE tp.trainer_id = $1 " +
+                "ORDER BY p.id";
+
+        return client.preparedQuery(query).execute(Tuple.of(trainerId))
                 .onItem().transformToMulti(rows -> Multi.createFrom().iterable(rows))
                 .onItem().transform(Pokemon::fromRecord);
     }

--- a/src/test/java/mx/tiempor3al/RootResourceTest.java
+++ b/src/test/java/mx/tiempor3al/RootResourceTest.java
@@ -72,4 +72,64 @@ class RootResourceTest {
                 .body("[0].speed", is(90))
                 .body("[0].description", is("An Electric-type Pokemon that stores electricity in its cheeks"));
     }
+
+    @Test
+    void testPokemonsByTrainerEndpoint() {
+        // Create a sample Pokemon record
+        Pokemon pokemon = new Pokemon(
+            1L,
+            "Pikachu",
+            4L,
+            "Electric",
+            new BigDecimal("0.4"),
+            new BigDecimal("6.0"),
+            35,
+            55,
+            40,
+            50,
+            50,
+            90,
+            "An Electric-type Pokemon that stores electricity in its cheeks"
+        );
+
+        Long trainerId = 1L;
+
+        // Mock the DBService to return a stream with our sample Pokemon for the given trainer
+        when(dbService.getPokemonsByTrainer(trainerId)).thenReturn(Multi.createFrom().item(pokemon));
+
+        // Test the endpoint
+        given()
+            .when().get("/trainers/" + trainerId + "/pokemons")
+            .then()
+                .statusCode(200)
+                .body("[0].id", is(1))
+                .body("[0].name", is("Pikachu"))
+                .body("[0].typeId", is(4))
+                .body("[0].typeName", is("Electric"))
+                .body("[0].height", is(0.4f))
+                .body("[0].weight", is(6.0f))
+                .body("[0].hp", is(35))
+                .body("[0].attack", is(55))
+                .body("[0].defense", is(40))
+                .body("[0].specialAttack", is(50))
+                .body("[0].specialDefense", is(50))
+                .body("[0].speed", is(90))
+                .body("[0].description", is("An Electric-type Pokemon that stores electricity in its cheeks"));
+    }
+
+    @Test
+    void testPokemonsByTrainerEndpointNotFound() {
+        // Use a trainer ID that doesn't exist
+        Long nonExistentTrainerId = 999L;
+
+        // Mock the DBService to return an empty stream for the non-existent trainer
+        when(dbService.getPokemonsByTrainer(nonExistentTrainerId)).thenReturn(Multi.createFrom().empty());
+
+        // Test the endpoint - should return 200 OK with an empty array
+        given()
+            .when().get("/trainers/" + nonExistentTrainerId + "/pokemons")
+            .then()
+                .statusCode(200)
+                .body("", is(java.util.Collections.emptyList()));
+    }
 }


### PR DESCRIPTION
…ic Pokemon:

- Extend `RootResource` with a new endpoint to retrieve Pokemon by trainer ID.
- Implement `getPokemonsByTrainer` method in `DBService` for database access.
- Enhance tests to cover new endpoint functionality, including trainer-specific cases and edge scenarios.